### PR TITLE
The have_c_compiler() method should calling via $self->builder().

### DIFF
--- a/lib/Module/Build/Pluggable/CheckLib.pm
+++ b/lib/Module/Build/Pluggable/CheckLib.pm
@@ -8,7 +8,7 @@ use parent qw/Module::Build::Pluggable::Base/;
 
 sub HOOK_configure {
     my $self = shift;
-    unless ($self->have_c_compiler()) {
+    unless ($self->builder->have_c_compiler()) {
         warn "This distribution requires a C compiler, but it's not available, stopped.(OS unsupported)\n";
         exit 0;
     }


### PR DESCRIPTION
When using Module::Build::Pluggable::CheckLib, the following error occurs.

```
$ perl Build.PL
Can't locate object method "have_c_compiler" via package "Module::Build::Pluggable::CheckLib"  (snip)
```

The have_c_compiler() method should calling via $self->builder().
