### PR TITLE
spelling error for cygwin installs

### DIFF
--- a/lib/Module/Build/Pluggable/XSUtil.pm
+++ b/lib/Module/Build/Pluggable/XSUtil.pm
@@ -56,7 +56,7 @@ sub HOOK_configure {
 
     # cleanup options
     if ($^O eq 'cygwin') {
-        $self->bulder->add_to_cleanup('*.stackdump');
+        $self->builder->add_to_cleanup('*.stackdump');
     }
 
     # debugging options


### PR DESCRIPTION
This fails under cygwin.  Simple spelling error.
